### PR TITLE
Add GitHub Actions CI, Docker-first docs, and misc cleanup

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,7 +84,7 @@ jobs:
 
     # 6 ─ Prepare database schema (drops → recreates → migrates)
     - name: Run Diesel migrations
-      run: diesel database reset --no-interaction
+      run: diesel setup
 
     # 7 ─ Lint: Clippy (fails on warnings)
     - name: Run Clippy
@@ -106,7 +106,7 @@ jobs:
         cargo run --bin server &
         SERVER_PID=$!
         # Give it a moment to start up
-        sleep 5
+        sleep 3
         # Run test-suite (single thread avoids port contention)
         cargo test --all-features -- --test-threads=1 --verbose
         # Shut down server

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,113 @@
+name: Rust CI
+
+# ────────────────────────────────────────────────
+# Triggers
+# ────────────────────────────────────────────────
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# ────────────────────────────────────────────────
+# Global env (shared by all steps)
+# ────────────────────────────────────────────────
+env:
+  CARGO_TERM_COLOR: always
+  DATABASE_URL: postgres://postgres:postgres@localhost:5432/app_db
+  ROCKET_DATABASES: |
+    {
+      postgres={url=postgres://postgres:postgres@localhost:5432/app_db},
+      redis={url=redis://localhost:6379}
+    }
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    # ────────────────────────────────────────────
+    # Service containers (PostgreSQL + Redis)
+    # ────────────────────────────────────────────
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: app_db
+        ports: [5432:5432]
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:latest
+        ports: [6379:6379]
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+    # 1 ─ Checkout code
+    - uses: actions/checkout@v4
+
+    # 2 ─ Install Rust toolchain + components
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+        components: clippy,rustfmt
+
+    # 3 ─ Speed up builds by caching registry + target/
+    - name: Cache cargo registry and build artifacts
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    # 4 ─ System libs for Diesel (libpq)
+    - name: Install system dependencies
+      run: sudo apt-get update && sudo apt-get install -y libpq-dev pkg-config
+
+    # 5 ─ Install Diesel CLI (PostgreSQL only)
+    - name: Install Diesel CLI
+      run: cargo install diesel_cli --no-default-features --features postgres
+
+    # 6 ─ Prepare database schema (drops → recreates → migrates)
+    - name: Run Diesel migrations
+      run: diesel database reset --no-interaction
+
+    # 7 ─ Lint: Clippy (fails on warnings)
+    - name: Run Clippy
+      run: cargo clippy --all-targets --all-features -- -D warnings
+
+    # 8 ─ Formatting check
+    - name: Check rustfmt
+      run: cargo fmt -- --check
+
+    # 9 ─ Build code
+    - name: Build
+      run: cargo build --all-features --verbose
+
+    # 10 ─ Launch Rocket server in background & run tests
+    - name: Run tests
+      shell: bash
+      run: |
+        # Start server on 127.0.0.1:8000 (matches APP_HOST in tests)
+        cargo run --bin server &
+        SERVER_PID=$!
+        # Give it a moment to start up
+        sleep 5
+        # Run test-suite (single thread avoids port contention)
+        cargo test --all-features -- --test-threads=1 --verbose
+        # Shut down server
+        kill $SERVER_PID

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,25 +74,25 @@ jobs:
           target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-    # 4 ─ System libs for Diesel (libpq)
-    - name: Install system dependencies
-      run: sudo apt-get update && sudo apt-get install -y libpq-dev pkg-config
-
-    # 5 ─ Install Diesel CLI (PostgreSQL only)
-    - name: Install Diesel CLI
-      run: cargo install diesel_cli --no-default-features --features postgres
-
-    # 6 ─ Prepare database schema (drops → recreates → migrates)
-    - name: Run Diesel migrations
-      run: diesel setup
-
-    # 7 ─ Lint: Clippy (fails on warnings)
+    # 4 ─ Lint: Clippy (fails on warnings)
     - name: Run Clippy
       run: cargo clippy --all-targets --all-features -- -D warnings
 
-    # 8 ─ Formatting check
+    # 5 ─ Formatting check
     - name: Check rustfmt
       run: cargo fmt -- --check
+
+    # 6 ─ System libs for Diesel (libpq)
+    - name: Install system dependencies
+      run: sudo apt-get update && sudo apt-get install -y libpq-dev pkg-config
+
+    # 7 ─ Install Diesel CLI (PostgreSQL only)
+    - name: Install Diesel CLI
+      run: cargo install diesel_cli --no-default-features --features postgres
+
+    # 8 ─ Prepare database schema (drops → recreates → migrates)
+    - name: Run Diesel migrations (diesel setup)
+      run: diesel setup
 
     # 9 ─ Build code
     - name: Build
@@ -108,6 +108,6 @@ jobs:
         # Give it a moment to start up
         sleep 3
         # Run test-suite (single thread avoids port contention)
-        cargo test --all-features -- --test-threads=1 --verbose
+        cargo test --all-features -- --test-threads=1
         # Shut down server
         kill $SERVER_PID

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ Cargo.lock
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+/TAGS
+*~
+*.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **GitHub Actions** workflow (`.github/workflows/rust.yml`) with Postgres + Redis
   service containers, Diesel migrations, lint, build, and test steps.
 - Docker-first quick-start and expanded docs in `README.md`.
-- `docs/native-workflow.md` (community-supported native setup).
+- `docs/docker-usage.md`: cheat-sheet of common Docker Compose commands.
+- `docs/native-workflow.md`: step-by-step native (non-Docker) setup guide.
 
 ### Changed
-- `docker-compose.yml`: removed deprecated `version:` key and prepared
-  `test_runner` service for cleaner test logging.
+- `docker-compose.yml`: removed deprecated `version:` key. Tests now run 
+   in the same `app` container.
 - Enabled `tokio` **macros** and **rt-multi-thread** features in `Cargo.toml`.
 - Replaced hand-written `ToString` with `Display` for `RoleCode`.
 - Ran `cargo fmt` and fixed assorted Clippy warnings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+All notable changes to **cr8s** will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- **GitHub Actions** workflow (`.github/workflows/rust.yml`) with Postgres + Redis
+  service containers, Diesel migrations, lint, build, and test steps.
+- Docker-first quick-start and expanded docs in `README.md`.
+- `docs/native-workflow.md` (community-supported native setup).
+
+### Changed
+- `docker-compose.yml`: removed deprecated `version:` key and prepared
+  `test_runner` service for cleaner test logging.
+- Enabled `tokio` **macros** and **rt-multi-thread** features in `Cargo.toml`.
+- Replaced hand-written `ToString` with `Display` for `RoleCode`.
+- Ran `cargo fmt` and fixed assorted Clippy warnings.
+- Login route now returns **401 Unauthorized** for invalid credentials.
+
+### Fixed
+- CI reproducibility: no host env-vars required; tests run against the
+  in-container server on `127.0.0.1:8000`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = "1"
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
 rocket = { version = "0.5", features = ["json"] }
 rocket_db_pools = { version = "0.1", features = ["diesel_postgres", "deadpool_redis"] }
 diesel = { version = "2.1", features = ["chrono"] }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,94 @@
 # cr8s
-Sample Web APIs with Rust
+
+Sample full‑stack **Rust** web service demonstrating Rocket, Diesel/PostgreSQL, Redis, Docker, and automated CI.
+
+---
+
+## ✨ What’s inside?
+
+| Layer | Tech | Purpose |
+|-------|------|---------|
+| HTTP  | **Rocket 0.5** | Async web framework |
+| DB    | **Diesel v2** + **PostgreSQL** | Relational data model & migrations |
+| Cache | **Redis** | Session / ephemeral storage |
+| Admin | CLI binary (`cargo run --bin cli`) | Manage users & seed data |
+| Tests | `tokio`, `reqwest` | Integration tests hitting live server |
+| Dev   | **Docker Compose** | One‑command reproducible stack |
+| CI    | **GitHub Actions** | Lint → migrate → build → test |
+
+---
+
+## 🛠️ Prerequisites
+
+```text
+Docker ≥ 24.x           # Engine
+Docker Compose v2       # Already bundled with modern Docker
+```
+
+> 📝 Prefer running everything natively? Check the community‑supported instructions in [`docs/native-workflow.md`](docs/native-workflow.md).
+
+---
+
+## 🚀 Quick start (Docker‑first workflow)
+
+```bash
+# 1. Clone & build
+$ git clone https://github.com/JohnBasrai/cr8s.git && cd cr8s
+$ docker compose build              # compiles Rust into the image
+
+# 2. Launch backing services (Postgres & Redis)
+$ docker compose up -d postgres redis
+
+# 3. Initialize database (idempotent)
+$ docker compose run --rm app diesel setup
+
+# 4. Run test‑suite via dedicated runner (stops stack when done)
+$ docker compose up --build --abort-on-container-exit test_runner
+
+# 5. Tear everything down
+$ docker compose down
+```
+
+*The `test_runner` service starts its own container, waits for the app server, and executes `cargo test -- --test-threads=1`. Logs from the server and the tests stay neatly separated.*
+
+* **No host env‑vars needed** – the `app` service already sets `DATABASE_URL` and `ROCKET_DATABASES` in *docker-compose.yml*, so Diesel, Rocket, and the test runner all see the right values automatically.
+* **Integrated server spin‑up** – the `test_runner` container starts Rocket on `127.0.0.1:8000` and the tests reach it via `reqwest`, exactly like in CI.
+* **Expected result** – when the suite finishes you should see something like `ok. 2 passed; 0 failed` (or however many tests exist).
+
+Need more Docker tips (stream logs, cURL pokes, DB maintenance)? See [`docs/docker-usage.md`](docs/docker-usage.md).
+
+---
+
+## 📂 Project layout
+
+```
+├── src/
+│   ├── bin/
+│   │   ├── server.rs        # Rocket entry‑point
+│   │   └── cli.rs           # Maintenance CLI
+│   └── lib.rs               # Shared domain logic
+├── tests/                   # Integration tests
+├── migrations/              # Diesel SQL migrations
+├── Dockerfile               # Application image
+├── docker-compose.yml       # Dev/CI stack definition
+├── docs/
+│   ├── docker-usage.md      # Extra Docker commands (optional)
+│   └── native-workflow.md   # Community‑supported native setup
+└── .github/workflows/
+    └── rust.yml             # CI pipeline
+```
+
+---
+
+## 🧪 Continuous Integration
+
+1) GitHub Actions spins up Postgres & Redis service containers
+2) installs `diesel_cli`
+3) runs `diesel setup`
+4) and executes the test runner
+
+Clippy and rustfmt are gated with `-D warnings`, so the main branch stays clean.
+
+---
+
+MIT © 2025 John Basrai

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.3'
 
 services:
   postgres:

--- a/docs/docker-usage.md
+++ b/docs/docker-usage.md
@@ -1,0 +1,53 @@
+# Docker usage tips
+
+A handful of everyday commands for working with **cr8s** via Docker Compose.
+
+---
+
+## Start the API for manual testing
+
+```bash
+# Build image & launch full stack (detached)
+docker compose up --build -d        # app + postgres + redis
+
+# Tail the Rocket logs
+docker compose logs -f app
+
+# Basic health‑check
+curl http://127.0.0.1:8000/health
+```
+
+---
+
+## One‑liner: recreate DB & rerun tests
+
+```bash
+docker compose down        # stop any running services
+docker compose up -d postgres redis
+# fresh migrations
+docker compose run --rm app diesel setup
+# run tests in isolated container
+docker compose run --rm --service-ports app \
+  bash -c 'cargo run --bin server & sleep 3 && cargo test -- --test-threads=1'
+```
+
+---
+
+## Database maintenance cheatsheet
+
+| Task               | Command                                                |
+| ------------------ | ------------------------------------------------------ |
+| Re‑run migrations  | `docker compose run --rm app diesel migration run`     |
+| Drop & recreate DB | `docker compose run --rm app diesel database reset`    |
+| psql shell         | `docker compose exec postgres psql -U postgres app_db` |
+| List tables        | `\dt` inside psql                                      |
+
+---
+
+## Clean up everything
+
+```bash
+docker compose down -v   # stops containers and removes named volumes
+```
+
+> Remove dangling images / build cache with `docker system prune` (optional).

--- a/docs/native-workflow.md
+++ b/docs/native-workflow.md
@@ -1,0 +1,84 @@
+# Native workflow (community-supported)
+
+> **Heads-up 🚧** The maintainer develops & tests with Docker only. These steps  
+> *should* work on any Linux / macOS / WSL host provided PostgreSQL client  
+> headers are present, but they are **not covered by CI**. If you refine them,  
+> please open a PR!
+
+---
+
+## 1  Install prerequisites
+
+Ubuntu example:
+
+```bash
+sudo apt-get update && sudo apt-get install -y libpq-dev pkg-config
+````
+
+Install **Diesel CLI** once (provides `diesel setup`):
+
+```bash
+cargo install diesel_cli --no-default-features --features postgres
+```
+
+---
+
+## 2  Launch services
+
+Run Postgres & Redis however you like (native packages, Homebrew, Docker). Quick Docker option:
+
+```bash
+# Postgres 16 on host port 5432
+docker run -d --name pg -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres:16
+
+# Redis on host port 6379
+docker run -d --name redis -p 6379:6379 redis:7
+```
+
+---
+
+## 3  Set environment variables
+
+```bash
+export DATABASE_URL=postgres://postgres:postgres@localhost:5432/app_db
+export ROCKET_DATABASES='{
+  postgres={url=postgres://postgres:postgres@localhost:5432/app_db},
+  redis={url=redis://localhost:6379}
+}'
+```
+
+---
+
+## 4  Create database and run migrations
+
+```bash
+diesel setup      # creates DB + runs SQL in migrations/
+```
+
+---
+
+## 5  Run the test-suite
+
+```bash
+cargo test --all-features -- --test-threads=1
+```
+
+This spawns an in-process Rocket server on **127.0.0.1:8000** and the tests hit it via `reqwest`.
+
+---
+
+## Troubleshooting
+
+| Symptom                       | Fix                                                                             |
+| ----------------------------- | ------------------------------------------------------------------------------- |
+| `diesel: command not found`   | Ensure `~/.cargo/bin` is in `$PATH`, or open a new shell after `cargo install`. |
+| `could not connect to server` | Verify Postgres is listening on **5432** and `DATABASE_URL` is correct.         |
+| Migration errors              | Confirm `diesel setup` completed without errors; check `migrations/`.           |
+| `REQWEST connect error`       | Make sure Rocket server is running and Redis is reachable on **6379**.          |
+
+---
+
+## Contributing
+
+If you automate these steps (systemd unit, Homebrew formula, Windows PowerShell, etc.) please submit a pull request – all improvements are welcome!
+

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,10 +1,10 @@
-use argon2::Argon2;
-use argon2::password_hash::Error;
-use argon2::{PasswordHasher, PasswordVerifier, PasswordHash};
-use argon2::password_hash::SaltString;
 use argon2::password_hash::rand_core::OsRng;
-use rand::Rng;
+use argon2::password_hash::Error;
+use argon2::password_hash::SaltString;
+use argon2::Argon2;
+use argon2::{PasswordHash, PasswordHasher, PasswordVerifier};
 use rand::distributions::Alphanumeric;
+use rand::Rng;
 
 use crate::models::User;
 

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,4 +1,4 @@
-use clap::{Command, Arg, value_parser};
+use clap::{value_parser, Arg, Command};
 
 extern crate cr8s;
 
@@ -17,44 +17,74 @@ async fn main() {
                         .arg_required_else_help(true)
                         .arg(Arg::new("username").required(true))
                         .arg(Arg::new("password").required(true))
-                        .arg(Arg::new("roles").required(true).num_args(1..).value_delimiter(','))
+                        .arg(
+                            Arg::new("roles")
+                                .required(true)
+                                .num_args(1..)
+                                .value_delimiter(','),
+                        ),
                 )
-                .subcommand(
-                    Command::new("list")
-                        .about("List existing users")
-                )
+                .subcommand(Command::new("list").about("List existing users"))
                 .subcommand(
                     Command::new("delete")
                         .about("Delete user by ID")
                         .arg_required_else_help(true)
-                        .arg(Arg::new("id").required(true).value_parser(value_parser!(i32)))
-                )
+                        .arg(
+                            Arg::new("id")
+                                .required(true)
+                                .value_parser(value_parser!(i32)),
+                        ),
+                ),
         )
         .subcommand(
             Command::new("digest-send")
                 .about("Send a digest with latest crates via email")
                 .arg(Arg::new("email").required(true))
-                .arg(Arg::new("hours_since").required(true).value_parser(value_parser!(i32)))
+                .arg(
+                    Arg::new("hours_since")
+                        .required(true)
+                        .value_parser(value_parser!(i32)),
+                ),
         )
         .get_matches();
 
     match matches.subcommand() {
         Some(("users", sub_matches)) => match sub_matches.subcommand() {
-            Some(("create", sub_matches)) => cr8s::commands::create_user(
-                sub_matches.get_one::<String>("username").unwrap().to_owned(),
-                sub_matches.get_one::<String>("password").unwrap().to_owned(),
-                sub_matches.get_many::<String>("roles").unwrap().map(|v| v.to_owned()).collect(),
-            ).await,
+            Some(("create", sub_matches)) => {
+                cr8s::commands::create_user(
+                    sub_matches
+                        .get_one::<String>("username")
+                        .unwrap()
+                        .to_owned(),
+                    sub_matches
+                        .get_one::<String>("password")
+                        .unwrap()
+                        .to_owned(),
+                    sub_matches
+                        .get_many::<String>("roles")
+                        .unwrap()
+                        .map(|v| v.to_owned())
+                        .collect(),
+                )
+                .await
+            }
             Some(("list", _)) => cr8s::commands::list_users().await,
-            Some(("delete", sub_matches)) => cr8s::commands::delete_user(
-                sub_matches.get_one::<i32>("id").unwrap().to_owned(),
-            ).await,
-            _ => {},
+            Some(("delete", sub_matches)) => {
+                cr8s::commands::delete_user(sub_matches.get_one::<i32>("id").unwrap().to_owned())
+                    .await
+            }
+            _ => {}
         },
-        Some(("digest-send", sub_matches)) => cr8s::commands::digest_send(
-            sub_matches.get_one::<String>("email").unwrap().to_owned(),
-            sub_matches.get_one::<i32>("hours_since").unwrap().to_owned(),
-        ).await,
-        _ => {},
+        Some(("digest-send", sub_matches)) => {
+            cr8s::commands::digest_send(
+                sub_matches.get_one::<String>("email").unwrap().to_owned(),
+                sub_matches
+                    .get_one::<i32>("hours_since")
+                    .unwrap()
+                    .to_owned(),
+            )
+            .await
+        }
+        _ => {}
     }
 }

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -5,21 +5,24 @@ use rocket_db_pools::Database;
 #[rocket::main]
 async fn main() {
     let _ = rocket::build()
-        .mount("/", rocket::routes![
-            cr8s::rocket_routes::options,
-            cr8s::rocket_routes::authorization::me,
-            cr8s::rocket_routes::authorization::login,
-            cr8s::rocket_routes::rustaceans::get_rustaceans,
-            cr8s::rocket_routes::rustaceans::view_rustacean,
-            cr8s::rocket_routes::rustaceans::create_rustacean,
-            cr8s::rocket_routes::rustaceans::update_rustacean,
-            cr8s::rocket_routes::rustaceans::delete_rustacean,
-            cr8s::rocket_routes::crates::get_crates,
-            cr8s::rocket_routes::crates::view_crate,
-            cr8s::rocket_routes::crates::create_crate,
-            cr8s::rocket_routes::crates::update_crate,
-            cr8s::rocket_routes::crates::delete_crate,
-        ])
+        .mount(
+            "/",
+            rocket::routes![
+                cr8s::rocket_routes::options,
+                cr8s::rocket_routes::authorization::me,
+                cr8s::rocket_routes::authorization::login,
+                cr8s::rocket_routes::rustaceans::get_rustaceans,
+                cr8s::rocket_routes::rustaceans::view_rustacean,
+                cr8s::rocket_routes::rustaceans::create_rustacean,
+                cr8s::rocket_routes::rustaceans::update_rustacean,
+                cr8s::rocket_routes::rustaceans::delete_rustacean,
+                cr8s::rocket_routes::crates::get_crates,
+                cr8s::rocket_routes::crates::view_crate,
+                cr8s::rocket_routes::crates::create_crate,
+                cr8s::rocket_routes::crates::update_crate,
+                cr8s::rocket_routes::crates::delete_crate,
+            ],
+        )
         .attach(cr8s::rocket_routes::Cors)
         .attach(cr8s::rocket_routes::CacheConn::init())
         .attach(cr8s::rocket_routes::DbConn::init())

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,23 +1,22 @@
 use std::str::FromStr;
 
-use chrono::{Utc, Datelike};
-use diesel_async::{AsyncPgConnection, AsyncConnection};
-use tera::{Tera, Context};
+use chrono::{Datelike, Utc};
+use diesel_async::{AsyncConnection, AsyncPgConnection};
+use tera::{Context, Tera};
 
 use crate::auth;
 use crate::mail::HtmlMailer;
 use crate::models::{NewUser, RoleCode};
-use crate::repositories::{UserRepository, RoleRepository, CrateRepository};
+use crate::repositories::{CrateRepository, RoleRepository, UserRepository};
 
 fn load_template_engine() -> Tera {
-    Tera::new("templates/**/*.html")
-        .expect("Cannot load template engine")
+    Tera::new("templates/**/*.html").expect("Cannot load template engine")
 }
 
 async fn load_db_connection() -> AsyncPgConnection {
-    let database_url = std::env::var("DATABASE_URL")
-        .expect("Cannot load DB url from environment");
-    AsyncPgConnection::establish(&database_url).await
+    let database_url = std::env::var("DATABASE_URL").expect("Cannot load DB url from environment");
+    AsyncPgConnection::establish(&database_url)
+        .await
         .expect("Cannot connect to Postgres")
 }
 
@@ -25,9 +24,17 @@ pub async fn create_user(username: String, password: String, role_codes: Vec<Str
     let mut c = load_db_connection().await;
 
     let password_hash = auth::hash_password(password).unwrap();
-    let new_user = NewUser { username, password: password_hash };
-    let role_enums = role_codes.iter().map(|v| RoleCode::from_str(v.as_str()).unwrap()).collect();
-    let user = UserRepository::create(&mut c, new_user, role_enums).await.unwrap();
+    let new_user = NewUser {
+        username,
+        password: password_hash,
+    };
+    let role_enums = role_codes
+        .iter()
+        .map(|v| RoleCode::from_str(v.as_str()).unwrap())
+        .collect();
+    let user = UserRepository::create(&mut c, new_user, role_enums)
+        .await
+        .unwrap();
     println!("User created {:?}", user);
     let roles = RoleRepository::find_by_user(&mut c, &user).await.unwrap();
     println!("Roles assigned {:?}", roles);
@@ -52,22 +59,28 @@ pub async fn digest_send(email: String, hours_since: i32) {
     let mut c = load_db_connection().await;
     let tera = load_template_engine();
 
-    let crates = CrateRepository::find_since(&mut c, hours_since).await.unwrap();
-    if crates.len() > 0 {
+    let crates = CrateRepository::find_since(&mut c, hours_since)
+        .await
+        .unwrap();
+    if !crates.is_empty() {
         println!("Sending digest for {} crates", crates.len());
         let year = Utc::now().year();
         let mut context = Context::new();
         context.insert("crates", &crates);
         context.insert("year", &year);
 
-        let smtp_host = std::env::var("SMTP_HOST")
-            .expect("Cannot load SMTP host from environment");
-        let smtp_username = std::env::var("SMTP_USERNAME")
-            .expect("Cannot load SMTP username from environment");
-        let smtp_password = std::env::var("SMTP_PASSWORD")
-            .expect("Cannot load SMTP password from environment");
+        let smtp_host = std::env::var("SMTP_HOST").expect("Cannot load SMTP host from environment");
+        let smtp_username =
+            std::env::var("SMTP_USERNAME").expect("Cannot load SMTP username from environment");
+        let smtp_password =
+            std::env::var("SMTP_PASSWORD").expect("Cannot load SMTP password from environment");
 
-        let mailer = HtmlMailer { template_engine: tera, smtp_host, smtp_username, smtp_password };
+        let mailer = HtmlMailer {
+            template_engine: tera,
+            smtp_host,
+            smtp_username,
+            smtp_password,
+        };
         mailer.send(email, "email/digest.html", context).unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 mod auth;
+pub mod commands;
 mod mail;
 mod models;
-mod schema;
 mod repositories;
-pub mod commands;
 pub mod rocket_routes;
+mod schema;

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -1,10 +1,10 @@
-use std::error::Error;
+use lettre::message::header::ContentType;
+use lettre::message::MessageBuilder;
+use lettre::transport::smtp::authentication::Credentials;
 use lettre::transport::smtp::response::Response;
 use lettre::{SmtpTransport, Transport};
-use lettre::message::MessageBuilder;
-use lettre::message::header::ContentType;
-use lettre::transport::smtp::authentication::Credentials;
-use tera::{Tera, Context};
+use std::error::Error;
+use tera::{Context, Tera};
 
 pub struct HtmlMailer {
     pub template_engine: Tera,
@@ -14,9 +14,15 @@ pub struct HtmlMailer {
 }
 
 impl HtmlMailer {
-    pub fn send(self, to: String, template_name: &str, template_context: Context) -> Result<Response, Box<dyn Error>> {
-
-        let html_body = self.template_engine.render(template_name, &template_context)?;
+    pub fn send(
+        self,
+        to: String,
+        template_name: &str,
+        template_context: Context,
+    ) -> Result<Response, Box<dyn Error>> {
+        let html_body = self
+            .template_engine
+            .render(template_name, &template_context)?;
 
         let message = MessageBuilder::new()
             .subject("Cr8s digest")

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,15 +1,16 @@
+use std::fmt;
 use std::io::Write;
 use std::str::FromStr;
 
-use chrono::NaiveDateTime;
-use diesel::serialize::ToSql;
-use diesel::deserialize::FromSql;
-use diesel::pg::{Pg, PgValue};
-use diesel::{prelude::*, deserialize::FromSqlRow};
-use diesel::expression::AsExpression;
-use diesel::sql_types::Text;
 use crate::schema::*;
-use serde::{Serialize, Deserialize};
+use chrono::NaiveDateTime;
+use diesel::deserialize::FromSql;
+use diesel::expression::AsExpression;
+use diesel::pg::{Pg, PgValue};
+use diesel::serialize::ToSql;
+use diesel::sql_types::Text;
+use diesel::{deserialize::FromSqlRow, prelude::*};
+use serde::{Deserialize, Serialize};
 
 #[derive(Queryable, Serialize, Deserialize)]
 pub struct Rustacean {
@@ -57,7 +58,7 @@ pub struct User {
     pub username: String,
     #[serde(skip_serializing)]
     pub password: String,
-    pub created_at: NaiveDateTime
+    pub created_at: NaiveDateTime,
 }
 
 #[derive(Insertable)]
@@ -72,7 +73,7 @@ pub struct Role {
     pub id: i32,
     pub code: RoleCode,
     pub name: String,
-    pub created_at: NaiveDateTime
+    pub created_at: NaiveDateTime,
 }
 
 #[derive(Insertable)]
@@ -106,13 +107,14 @@ pub enum RoleCode {
     Viewer,
 }
 
-impl ToString for RoleCode {
-    fn to_string(&self) -> String {
-        match self {
-            RoleCode::Admin => String::from("admin"),
-            RoleCode::Editor => String::from("editor"),
-            RoleCode::Viewer => String::from("viewer"),
-        }
+impl fmt::Display for RoleCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            RoleCode::Admin => "admin",
+            RoleCode::Editor => "editor",
+            RoleCode::Viewer => "viewer",
+        };
+        write!(f, "{s}")
     }
 }
 
@@ -141,7 +143,10 @@ impl FromSql<Text, Pg> for RoleCode {
 }
 
 impl ToSql<Text, Pg> for RoleCode {
-    fn to_sql<'b>(&'b self, out: &mut diesel::serialize::Output<'b, '_, Pg>) -> diesel::serialize::Result {
+    fn to_sql<'b>(
+        &'b self,
+        out: &mut diesel::serialize::Output<'b, '_, Pg>,
+    ) -> diesel::serialize::Result {
         match self {
             RoleCode::Admin => out.write_all(b"admin")?,
             RoleCode::Editor => out.write_all(b"editor")?,

--- a/src/rocket_routes/crates.rs
+++ b/src/rocket_routes/crates.rs
@@ -1,6 +1,6 @@
 use crate::models::{Crate, NewCrate, User};
 use crate::repositories::CrateRepository;
-use crate::rocket_routes::{DbConn, EditorUser, server_error};
+use crate::rocket_routes::{server_error, DbConn, EditorUser};
 use rocket::http::Status;
 use rocket::response::status::{Custom, NoContent};
 use rocket::serde::json::{json, Json, Value};
@@ -8,35 +8,57 @@ use rocket_db_pools::Connection;
 
 #[rocket::get("/crates")]
 pub async fn get_crates(mut db: Connection<DbConn>, _user: User) -> Result<Value, Custom<Value>> {
-    CrateRepository::find_multiple(&mut db, 100).await
+    CrateRepository::find_multiple(&mut db, 100)
+        .await
         .map(|crates| json!(crates))
         .map_err(|e| server_error(e.into()))
 }
 
 #[rocket::get("/crates/<id>")]
-pub async fn view_crate(mut db: Connection<DbConn>, id: i32, _user: User) -> Result<Value, Custom<Value>> {
-    CrateRepository::find(&mut db, id).await
+pub async fn view_crate(
+    mut db: Connection<DbConn>,
+    id: i32,
+    _user: User,
+) -> Result<Value, Custom<Value>> {
+    CrateRepository::find(&mut db, id)
+        .await
         .map(|a_crate| json!(a_crate))
         .map_err(|e| server_error(e.into()))
 }
 
-#[rocket::post("/crates", format="json", data="<new_crate>")]
-pub async fn create_crate(mut db: Connection<DbConn>, new_crate: Json<NewCrate>, _user: EditorUser) -> Result<Custom<Value>, Custom<Value>> {
-    CrateRepository::create(&mut db, new_crate.into_inner()).await
+#[rocket::post("/crates", format = "json", data = "<new_crate>")]
+pub async fn create_crate(
+    mut db: Connection<DbConn>,
+    new_crate: Json<NewCrate>,
+    _user: EditorUser,
+) -> Result<Custom<Value>, Custom<Value>> {
+    CrateRepository::create(&mut db, new_crate.into_inner())
+        .await
         .map(|a_crate| Custom(Status::Created, json!(a_crate)))
         .map_err(|e| server_error(e.into()))
 }
 
-#[rocket::put("/crates/<id>", format="json", data="<a_crate>")]
-pub async fn update_crate(mut db: Connection<DbConn>, id: i32, a_crate: Json<Crate>, _user: EditorUser) -> Result<Value, Custom<Value>> {
-    CrateRepository::update(&mut db, id, a_crate.into_inner()).await
+#[rocket::put("/crates/<id>", format = "json", data = "<a_crate>")]
+pub async fn update_crate(
+    mut db: Connection<DbConn>,
+    id: i32,
+    a_crate: Json<Crate>,
+    _user: EditorUser,
+) -> Result<Value, Custom<Value>> {
+    CrateRepository::update(&mut db, id, a_crate.into_inner())
+        .await
         .map(|a_crate| json!(a_crate))
         .map_err(|e| server_error(e.into()))
 }
 
 #[rocket::delete("/crates/<id>")]
-pub async fn delete_crate(mut db: Connection<DbConn>, id: i32, _user: EditorUser) -> Result<NoContent, Custom<Value>> {
-    CrateRepository::delete(&mut db, id).await
+pub async fn delete_crate(
+    mut db: Connection<DbConn>,
+    id: i32,
+    _user: EditorUser,
+) -> Result<NoContent, Custom<Value>> {
+    CrateRepository::delete(&mut db, id)
+        .await
         .map(|_| NoContent)
         .map_err(|e| server_error(e.into()))
 }

--- a/src/rocket_routes/mod.rs
+++ b/src/rocket_routes/mod.rs
@@ -1,16 +1,16 @@
-use std::error::Error;
-use rocket::{Request, Response};
 use rocket::fairing::{Fairing, Info, Kind};
+use rocket::{Request, Response};
+use std::error::Error;
 
 use rocket::http::Status;
 use rocket::request::{FromRequest, Outcome};
 use rocket::response::status::Custom;
 use rocket::serde::json::{json, Value};
-use rocket_db_pools::Connection;
 use rocket_db_pools::deadpool_redis::redis::AsyncCommands;
+use rocket_db_pools::Connection;
 
-use crate::models::{User, RoleCode};
-use crate::repositories::{UserRepository, RoleRepository};
+use crate::models::{RoleCode, User};
+use crate::repositories::{RoleRepository, UserRepository};
 
 pub mod authorization;
 pub mod crates;
@@ -41,7 +41,7 @@ impl Fairing for Cors {
     fn info(&self) -> Info {
         Info {
             name: "Append CORS headers in responses",
-            kind: Kind::Response
+            kind: Kind::Response,
         }
     }
 
@@ -53,23 +53,30 @@ impl Fairing for Cors {
     }
 }
 
-
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for User {
     type Error = ();
 
     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
         // Authorization: Bearer SESSION_ID_128_CHARACTERS_LONG
-        let session_header = req.headers().get_one("Authorization")
+        let session_header = req
+            .headers()
+            .get_one("Authorization")
             .map(|v| v.split_whitespace().collect::<Vec<_>>())
             .filter(|v| v.len() == 2 && v[0] == "Bearer");
         if let Some(header_value) = session_header {
-            let mut cache = req.guard::<Connection<CacheConn>>().await
+            let mut cache = req
+                .guard::<Connection<CacheConn>>()
+                .await
                 .expect("Can not connect to Redis in request guard");
-            let mut db = req.guard::<Connection<DbConn>>().await
+            let mut db = req
+                .guard::<Connection<DbConn>>()
+                .await
                 .expect("Can not connect to Postgres in request guard");
 
-            let result = cache.get::<String, i32>(format!("sessions/{}", header_value[1])).await;
+            let result = cache
+                .get::<String, i32>(format!("sessions/{}", header_value[1]))
+                .await;
             if let Ok(user_id) = result {
                 if let Ok(user) = UserRepository::find(&mut db, user_id).await {
                     return Outcome::Success(user);
@@ -83,30 +90,40 @@ impl<'r> FromRequest<'r> for User {
 
 pub struct EditorUser(User);
 
+impl EditorUser {
+    pub fn into_inner(self) -> User {
+        self.0
+    }
+}
+
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for EditorUser {
+    // ---
     type Error = ();
 
     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        let user = req.guard::<User>().await
+        let user = req
+            .guard::<User>()
+            .await
             .expect("Cannot retrieve current logged in user");
-        let mut db = req.guard::<Connection<DbConn>>().await
+        let mut db = req
+            .guard::<Connection<DbConn>>()
+            .await
             .expect("Can not connect to Postgres in request guard");
 
         if let Ok(roles) = RoleRepository::find_by_user(&mut db, &user).await {
             rocket::info!("Roles assigned are {:?}", roles);
-            let is_editor = roles.iter().any(|r| match r.code {
-                RoleCode::Admin => true,
-                RoleCode::Editor => true,
-                _ => false
-            });
+
+            let is_editor = roles
+                .iter()
+                .any(|r| matches!(r.code, RoleCode::Admin | RoleCode::Editor));
+
             rocket::info!("Is editor is {:?}", is_editor);
 
             if is_editor {
                 return Outcome::Success(EditorUser(user));
             }
         }
-
 
         Outcome::Error((Status::Unauthorized, ()))
     }

--- a/src/rocket_routes/rustaceans.rs
+++ b/src/rocket_routes/rustaceans.rs
@@ -1,42 +1,67 @@
 use crate::models::{NewRustacean, Rustacean, User};
 use crate::repositories::RustaceanRepository;
-use crate::rocket_routes::{DbConn, EditorUser, server_error};
+use crate::rocket_routes::{server_error, DbConn, EditorUser};
 use rocket::http::Status;
 use rocket::response::status::{Custom, NoContent};
 use rocket::serde::json::{json, Json, Value};
 use rocket_db_pools::Connection;
 
 #[rocket::get("/rustaceans")]
-pub async fn get_rustaceans(mut db: Connection<DbConn>, _user: User) -> Result<Value, Custom<Value>> {
-    RustaceanRepository::find_multiple(&mut db, 100).await
+pub async fn get_rustaceans(
+    mut db: Connection<DbConn>,
+    _user: User,
+) -> Result<Value, Custom<Value>> {
+    RustaceanRepository::find_multiple(&mut db, 100)
+        .await
         .map(|rustaceans| json!(rustaceans))
         .map_err(|e| server_error(e.into()))
 }
 
 #[rocket::get("/rustaceans/<id>")]
-pub async fn view_rustacean(mut db: Connection<DbConn>, id: i32, _user: User) -> Result<Value, Custom<Value>> {
-    RustaceanRepository::find(&mut db, id).await
+pub async fn view_rustacean(
+    mut db: Connection<DbConn>,
+    id: i32,
+    _user: User,
+) -> Result<Value, Custom<Value>> {
+    RustaceanRepository::find(&mut db, id)
+        .await
         .map(|rustacean| json!(rustacean))
         .map_err(|e| server_error(e.into()))
 }
 
-#[rocket::post("/rustaceans", format="json", data="<new_rustacean>")]
-pub async fn create_rustacean(mut db: Connection<DbConn>, new_rustacean: Json<NewRustacean>, _user: EditorUser) -> Result<Custom<Value>, Custom<Value>> {
-    RustaceanRepository::create(&mut db, new_rustacean.into_inner()).await
+#[rocket::post("/rustaceans", format = "json", data = "<new_rustacean>")]
+pub async fn create_rustacean(
+    mut db: Connection<DbConn>,
+    new_rustacean: Json<NewRustacean>,
+    _user: EditorUser,
+) -> Result<Custom<Value>, Custom<Value>> {
+    RustaceanRepository::create(&mut db, new_rustacean.into_inner())
+        .await
         .map(|rustacean| Custom(Status::Created, json!(rustacean)))
         .map_err(|e| server_error(e.into()))
 }
 
-#[rocket::put("/rustaceans/<id>", format="json", data="<rustacean>")]
-pub async fn update_rustacean(mut db: Connection<DbConn>, id: i32, rustacean: Json<Rustacean>, _user: EditorUser) -> Result<Value, Custom<Value>> {
-    RustaceanRepository::update(&mut db, id, rustacean.into_inner()).await
+#[rocket::put("/rustaceans/<id>", format = "json", data = "<rustacean>")]
+pub async fn update_rustacean(
+    mut db: Connection<DbConn>,
+    id: i32,
+    rustacean: Json<Rustacean>,
+    _user: EditorUser,
+) -> Result<Value, Custom<Value>> {
+    RustaceanRepository::update(&mut db, id, rustacean.into_inner())
+        .await
         .map(|rustacean| json!(rustacean))
         .map_err(|e| server_error(e.into()))
 }
 
 #[rocket::delete("/rustaceans/<id>")]
-pub async fn delete_rustacean(mut db: Connection<DbConn>, id: i32, _user: EditorUser) -> Result<NoContent, Custom<Value>> {
-    RustaceanRepository::delete(&mut db, id).await
+pub async fn delete_rustacean(
+    mut db: Connection<DbConn>,
+    id: i32,
+    _user: EditorUser,
+) -> Result<NoContent, Custom<Value>> {
+    RustaceanRepository::delete(&mut db, id)
+        .await
         .map(|_| NoContent)
         .map_err(|e| server_error(e.into()))
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -58,10 +58,4 @@ diesel::joinable!(crates -> rustaceans (rustacean_id));
 diesel::joinable!(users_roles -> roles (role_id));
 diesel::joinable!(users_roles -> users (user_id));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    crates,
-    roles,
-    rustaceans,
-    users,
-    users_roles,
-);
+diesel::allow_tables_to_appear_in_same_query!(crates, roles, rustaceans, users, users_roles,);

--- a/tests/authorization.rs
+++ b/tests/authorization.rs
@@ -1,6 +1,6 @@
-use std::process::Command;
 use reqwest::{blocking::Client, StatusCode};
 use serde_json::{json, Value};
+use std::process::Command;
 
 pub mod common;
 
@@ -24,7 +24,8 @@ fn test_login() {
     let client = Client::new();
 
     // Test
-    let response = client.post(format!("{}/login", common::APP_HOST))
+    let response = client
+        .post(format!("{}/login", common::APP_HOST))
         .json(&json!({
             "username": "test_admin",
             "password": "1234",
@@ -36,7 +37,8 @@ fn test_login() {
     assert!(json.get("token").is_some());
     assert_eq!(json["token"].as_str().unwrap().len(), 128);
 
-    let response = client.post(format!("{}/login", common::APP_HOST))
+    let response = client
+        .post(format!("{}/login", common::APP_HOST))
         .json(&json!({
             "username": "test_admin",
             "password": "12345",
@@ -50,7 +52,8 @@ fn test_login() {
 fn test_me() {
     let client = common::get_client_with_logged_in_viewer();
 
-    let response = client.get(format!("{}/me", common::APP_HOST))
+    let response = client
+        .get(format!("{}/me", common::APP_HOST))
         .send()
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,13 +1,14 @@
-use std::process::Command;
 use reqwest::blocking::{Client, ClientBuilder};
-use reqwest::StatusCode;
 use reqwest::header;
+use reqwest::StatusCode;
 use serde_json::{json, Value};
+use std::process::Command;
 
-pub static APP_HOST: &'static str = "http://127.0.0.1:8000";
+pub static APP_HOST: &str = "http://127.0.0.1:8000";
 
 pub fn create_test_rustacean(client: &Client) -> Value {
-    let response = client.post(format!("{}/rustaceans", APP_HOST))
+    let response = client
+        .post(format!("{}/rustaceans", APP_HOST))
         .json(&json!({
             "name": "Foo bar",
             "email": "foo@bar.com"
@@ -16,11 +17,12 @@ pub fn create_test_rustacean(client: &Client) -> Value {
         .unwrap();
     assert_eq!(response.status(), StatusCode::CREATED);
 
-   response.json().unwrap()
+    response.json().unwrap()
 }
 
 pub fn create_test_crate(client: &Client, rustacean: &Value) -> Value {
-    let response = client.post(format!("{}/crates", APP_HOST))
+    let response = client
+        .post(format!("{}/crates", APP_HOST))
         .json(&json!({
             "rustacean_id": rustacean["id"],
             "code": "foo",
@@ -32,18 +34,20 @@ pub fn create_test_crate(client: &Client, rustacean: &Value) -> Value {
         .unwrap();
     assert_eq!(response.status(), StatusCode::CREATED);
 
-   response.json().unwrap()
+    response.json().unwrap()
 }
 
 pub fn delete_test_rustacean(client: &Client, rustacean: Value) {
-    let response = client.delete(format!("{}/rustaceans/{}", APP_HOST, rustacean["id"]))
+    let response = client
+        .delete(format!("{}/rustaceans/{}", APP_HOST, rustacean["id"]))
         .send()
         .unwrap();
     assert_eq!(response.status(), StatusCode::NO_CONTENT);
 }
 
 pub fn delete_test_crate(client: &Client, a_crate: Value) {
-    let response = client.delete(format!("{}/crates/{}", APP_HOST, a_crate["id"]))
+    let response = client
+        .delete(format!("{}/crates/{}", APP_HOST, a_crate["id"]))
         .send()
         .unwrap();
     assert_eq!(response.status(), StatusCode::NO_CONTENT);
@@ -63,7 +67,8 @@ pub fn get_logged_in_client(username: &str, role: &str) -> Client {
         .unwrap();
 
     let client = Client::new();
-    let response = client.post(format!("{}/login", APP_HOST))
+    let response = client
+        .post(format!("{}/login", APP_HOST))
         .json(&json!({
             "username": username,
             "password": "1234",
@@ -78,10 +83,13 @@ pub fn get_logged_in_client(username: &str, role: &str) -> Client {
     let mut headers = header::HeaderMap::new();
     headers.insert(
         header::AUTHORIZATION,
-        header::HeaderValue::from_str(&header_value).unwrap()
+        header::HeaderValue::from_str(&header_value).unwrap(),
     );
 
-    ClientBuilder::new().default_headers(headers).build().unwrap()
+    ClientBuilder::new()
+        .default_headers(headers)
+        .build()
+        .unwrap()
 }
 
 pub fn get_client_with_logged_in_viewer() -> Client {

--- a/tests/crates.rs
+++ b/tests/crates.rs
@@ -1,8 +1,7 @@
-use reqwest::StatusCode;
+use reqwest::{Client, StatusCode};
 use serde_json::{json, Value};
 
 pub mod common;
-
 
 #[test]
 fn test_get_crates() {
@@ -14,7 +13,10 @@ fn test_get_crates() {
 
     // Test
     let client = common::get_client_with_logged_in_viewer();
-    let response = client.get(format!("{}/crates", common::APP_HOST)).send().unwrap();
+    let response = client
+        .get(format!("{}/crates", common::APP_HOST))
+        .send()
+        .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     let json: Value = response.json().unwrap();
     assert!(json.as_array().unwrap().contains(&a_crate));
@@ -27,14 +29,17 @@ fn test_get_crates() {
     common::delete_test_rustacean(&client, rustacean);
 }
 
-#[test]
-fn test_get_crates_not_loggedin_fails() {
+#[tokio::test]
+async fn test_get_crates_not_loggedin_fails() {
     // Setup
     let client = Client::new();
-    let response = client.get(format!("{}/crates", common::APP_HOST)).send().unwrap();
+    let response = client
+        .get(format!("{}/crates", common::APP_HOST))
+        .send()
+        .await
+        .unwrap();
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
-
 
 #[test]
 fn test_create_crate() {
@@ -43,7 +48,8 @@ fn test_create_crate() {
     let rustacean = common::create_test_rustacean(&client);
 
     // Test
-    let response = client.post(format!("{}/crates", common::APP_HOST))
+    let response = client
+        .post(format!("{}/crates", common::APP_HOST))
         .json(&json!({
             "rustacean_id": rustacean["id"],
             "code": "foo",
@@ -56,15 +62,18 @@ fn test_create_crate() {
     assert_eq!(response.status(), StatusCode::CREATED);
 
     let a_crate: Value = response.json().unwrap();
-    assert_eq!(a_crate, json!({
-        "id": a_crate["id"],
-        "code": "foo",
-        "name": "Foo crate",
-        "version": "0.1",
-        "description": "Foo crate description",
-        "rustacean_id": rustacean["id"],
-        "created_at": a_crate["created_at"],
-    }));
+    assert_eq!(
+        a_crate,
+        json!({
+            "id": a_crate["id"],
+            "code": "foo",
+            "name": "Foo crate",
+            "version": "0.1",
+            "description": "Foo crate description",
+            "rustacean_id": rustacean["id"],
+            "created_at": a_crate["created_at"],
+        })
+    );
 
     // Cleanup
     common::delete_test_crate(&client, a_crate);
@@ -80,21 +89,25 @@ fn test_view_crate() {
 
     // Test
     let client = common::get_client_with_logged_in_viewer();
-    let response = client.get(format!("{}/crates/{}", common::APP_HOST, a_crate["id"]))
+    let response = client
+        .get(format!("{}/crates/{}", common::APP_HOST, a_crate["id"]))
         .send()
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
     let a_crate: Value = response.json().unwrap();
-    assert_eq!(a_crate, json!({
-        "id": a_crate["id"],
-        "code": "foo",
-        "name": "Foo crate",
-        "version": "0.1",
-        "description": "Foo crate description",
-        "rustacean_id": rustacean["id"],
-        "created_at": a_crate["created_at"],
-    }));
+    assert_eq!(
+        a_crate,
+        json!({
+            "id": a_crate["id"],
+            "code": "foo",
+            "name": "Foo crate",
+            "version": "0.1",
+            "description": "Foo crate description",
+            "rustacean_id": rustacean["id"],
+            "created_at": a_crate["created_at"],
+        })
+    );
 
     // Cleanup
     let client = common::get_client_with_logged_in_admin();
@@ -110,7 +123,8 @@ fn test_update_crate() {
     let a_crate = common::create_test_crate(&client, &rustacean);
 
     // Test
-    let response = client.put(format!("{}/crates/{}", common::APP_HOST, a_crate["id"]))
+    let response = client
+        .put(format!("{}/crates/{}", common::APP_HOST, a_crate["id"]))
         .json(&json!({
             "code": "fooz",
             "name": "Fooz crate",
@@ -123,15 +137,18 @@ fn test_update_crate() {
     assert_eq!(response.status(), StatusCode::OK);
 
     let a_crate: Value = response.json().unwrap();
-    assert_eq!(a_crate, json!({
-        "id": a_crate["id"],
-        "code": "fooz",
-        "name": "Fooz crate",
-        "version": "0.2",
-        "description": "Fooz crate description",
-        "rustacean_id": rustacean["id"],
-        "created_at": a_crate["created_at"],
-    }));
+    assert_eq!(
+        a_crate,
+        json!({
+            "id": a_crate["id"],
+            "code": "fooz",
+            "name": "Fooz crate",
+            "version": "0.2",
+            "description": "Fooz crate description",
+            "rustacean_id": rustacean["id"],
+            "created_at": a_crate["created_at"],
+        })
+    );
 
     // Test author-switching for a crate and a very long description.
     let rustacean2 = common::create_test_rustacean(&client);
@@ -148,15 +165,18 @@ fn test_update_crate() {
     assert_eq!(response.status(), StatusCode::OK);
 
     let a_crate: Value = response.json().unwrap();
-    assert_eq!(a_crate, json!({
-        "id": a_crate["id"],
-        "code": "fooz",
-        "name": "Fooz crate",
-        "version": "0.2",
-        "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque gravida aliquet arcu, non maximus urna iaculis et. Nam eu ante eu dolor volutpat maximus. Sed tincidunt pretium elementum. Quisque rutrum ex id sem luctus rhoncus ac ultrices lacus. Ut vulputate magna facilisis dignissim porttitor. Nulla vitae pretium neque. Vestibulum rutrum semper justo, ut mattis diam. Curabitur a tempus felis. Pellentesque sit amet pharetra nunc. Curabitur est nunc, tincidunt sit amet arcu sed, bibendum accumsan ligula. Maecenas eu dolor sed mi viverra congue. Phasellus vel dignissim lacus, vel tempor velit. Vestibulum vulputate sapien nisi, ac ullamcorper enim sodales vitae. Aliquam erat volutpat. Etiam tincidunt aliquet velit ac vulputate. Aenean et augue dolor.",
-        "rustacean_id": rustacean2["id"],
-        "created_at": a_crate["created_at"],
-    }));
+    assert_eq!(
+        a_crate,
+        json!({
+            "id": a_crate["id"],
+            "code": "fooz",
+            "name": "Fooz crate",
+            "version": "0.2",
+            "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque gravida aliquet arcu, non maximus urna iaculis et. Nam eu ante eu dolor volutpat maximus. Sed tincidunt pretium elementum. Quisque rutrum ex id sem luctus rhoncus ac ultrices lacus. Ut vulputate magna facilisis dignissim porttitor. Nulla vitae pretium neque. Vestibulum rutrum semper justo, ut mattis diam. Curabitur a tempus felis. Pellentesque sit amet pharetra nunc. Curabitur est nunc, tincidunt sit amet arcu sed, bibendum accumsan ligula. Maecenas eu dolor sed mi viverra congue. Phasellus vel dignissim lacus, vel tempor velit. Vestibulum vulputate sapien nisi, ac ullamcorper enim sodales vitae. Aliquam erat volutpat. Etiam tincidunt aliquet velit ac vulputate. Aenean et augue dolor.",
+            "rustacean_id": rustacean2["id"],
+            "created_at": a_crate["created_at"],
+        })
+    );
 
     // Cleanup
     common::delete_test_crate(&client, a_crate);
@@ -171,7 +191,8 @@ fn test_delete_crate() {
     let a_crate = common::create_test_crate(&client, &rustacean);
 
     // Test
-    let response = client.delete(format!("{}/crates/{}", common::APP_HOST, a_crate["id"]))
+    let response = client
+        .delete(format!("{}/crates/{}", common::APP_HOST, a_crate["id"]))
         .send()
         .unwrap();
     assert_eq!(response.status(), StatusCode::NO_CONTENT);

--- a/tests/rustaceans.rs
+++ b/tests/rustaceans.rs
@@ -1,4 +1,4 @@
-use reqwest::StatusCode;
+use reqwest::{Client, StatusCode};
 use serde_json::{json, Value};
 
 pub mod common;
@@ -12,7 +12,10 @@ fn test_get_rustaceans() {
 
     // Test
     let client_view = common::get_client_with_logged_in_viewer();
-    let response = client_view.get(format!("{}/rustaceans", common::APP_HOST)).send().unwrap();
+    let response = client_view
+        .get(format!("{}/rustaceans", common::APP_HOST))
+        .send()
+        .unwrap();
 
     assert_eq!(response.status(), StatusCode::OK);
 
@@ -25,18 +28,23 @@ fn test_get_rustaceans() {
     common::delete_test_rustacean(&client_adm, rustacean2);
 }
 
-#[test]
-fn test_get_rustaceans_not_loggedin_fails() {
+#[tokio::test]
+async fn test_get_rustaceans_not_loggedin_fails() {
     // Setup
     let client = Client::new();
-    let response = client.get(format!("{}/rustaceans", common::APP_HOST)).send().unwrap();
+    let response = client
+        .get(format!("{}/rustaceans", common::APP_HOST))
+        .send()
+        .await
+        .unwrap();
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
 
 #[test]
 fn test_create_rustacean() {
     let client = common::get_client_with_logged_in_admin();
-    let response = client.post(format!("{}/rustaceans", common::APP_HOST))
+    let response = client
+        .post(format!("{}/rustaceans", common::APP_HOST))
         .json(&json!({
             "name": "Foo bar",
             "email": "foo@bar.com"
@@ -46,12 +54,15 @@ fn test_create_rustacean() {
     assert_eq!(response.status(), StatusCode::CREATED);
 
     let rustacean: Value = response.json().unwrap();
-    assert_eq!(rustacean, json!({
-        "id": rustacean["id"],
-        "name": "Foo bar",
-        "email": "foo@bar.com",
-        "created_at": rustacean["created_at"],
-    }));
+    assert_eq!(
+        rustacean,
+        json!({
+            "id": rustacean["id"],
+            "name": "Foo bar",
+            "email": "foo@bar.com",
+            "created_at": rustacean["created_at"],
+        })
+    );
 
     common::delete_test_rustacean(&client, rustacean);
 }
@@ -62,17 +73,25 @@ fn test_view_rustacean() {
     let rustacean = common::create_test_rustacean(&client);
 
     let client = common::get_client_with_logged_in_viewer();
-    let response = client.get(format!("{}/rustaceans/{}", common::APP_HOST, rustacean["id"]))
+    let response = client
+        .get(format!(
+            "{}/rustaceans/{}",
+            common::APP_HOST,
+            rustacean["id"]
+        ))
         .send()
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     let rustacean: Value = response.json().unwrap();
-    assert_eq!(rustacean, json!({
-        "id": rustacean["id"],
-        "name": "Foo bar",
-        "email": "foo@bar.com",
-        "created_at": rustacean["created_at"],
-    }));
+    assert_eq!(
+        rustacean,
+        json!({
+            "id": rustacean["id"],
+            "name": "Foo bar",
+            "email": "foo@bar.com",
+            "created_at": rustacean["created_at"],
+        })
+    );
 
     let client = common::get_client_with_logged_in_admin();
     common::delete_test_rustacean(&client, rustacean);
@@ -83,7 +102,12 @@ fn test_update_rustacean() {
     let client = common::get_client_with_logged_in_admin();
     let rustacean = common::create_test_rustacean(&client);
 
-    let response = client.put(format!("{}/rustaceans/{}", common::APP_HOST, rustacean["id"]))
+    let response = client
+        .put(format!(
+            "{}/rustaceans/{}",
+            common::APP_HOST,
+            rustacean["id"]
+        ))
         .json(&json!({
             "name": "Fooz bar",
             "email": "fooz@bar.com"
@@ -92,12 +116,15 @@ fn test_update_rustacean() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     let rustacean: Value = response.json().unwrap();
-    assert_eq!(rustacean, json!({
-        "id": rustacean["id"],
-        "name": "Fooz bar",
-        "email": "fooz@bar.com",
-        "created_at": rustacean["created_at"],
-    }));
+    assert_eq!(
+        rustacean,
+        json!({
+            "id": rustacean["id"],
+            "name": "Fooz bar",
+            "email": "fooz@bar.com",
+            "created_at": rustacean["created_at"],
+        })
+    );
 
     common::delete_test_rustacean(&client, rustacean);
 }
@@ -107,7 +134,12 @@ fn test_delete_rustacean() {
     let client = common::get_client_with_logged_in_admin();
     let rustacean = common::create_test_rustacean(&client);
 
-    let response = client.delete(format!("{}/rustaceans/{}", common::APP_HOST, rustacean["id"]))
+    let response = client
+        .delete(format!(
+            "{}/rustaceans/{}",
+            common::APP_HOST,
+            rustacean["id"]
+        ))
         .send()
         .unwrap();
     assert_eq!(response.status(), StatusCode::NO_CONTENT);


### PR DESCRIPTION
🚀 **Highlights**

* **CI** – new workflow (`.github/workflows/rust.yml`)  
  * Spins up **Postgres** + **Redis** service containers  
  * Installs `diesel_cli` → runs `diesel setup` (schema ready)  
  * Executes Clippy, rustfmt, build, and the full integration-test suite  
* **Docs**  
  * Replaced minimal **README** with Docker-first quick-start, feature matrix, and CI notes  
  * Added `docs/docker-usage.md` – everyday Compose commands  
  * Added `docs/native-workflow.md` – community-supported native setup  
* **Project hygiene**  
  * Added empty **CHANGELOG.md**; updated `.gitignore`  
  * Dropped deprecated `version:` key from *docker-compose.yml*  
  * Enabled extra Tokio features; ran `cargo fmt` & fixed Clippy lints  
  * Replaced custom `ToString` impl with `Display` for `RoleCode`  
  * API now returns **401 Unauthorized** on bad login credentials

---

🔧 **How to test locally**

```bash
docker compose build
docker compose up -d postgres redis
docker compose run --rm app diesel setup
docker compose run --rm --service-ports app \
  bash -c 'cargo run --bin server & sleep 3 && cargo test -- --test-threads=1'
docker compose down
```