### PR TITLE
docs(changelog): add 0.2.0 release notes and reference #4

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,4 @@
+# .cargo/audit.toml
+[advisories]
+# See [#4]: https://github.com/JohnBasrai/cr8s/issues/4
+ignore = ["RUSTSEC-2024-0365"]   # Diesel 2.1 Binary-protocol truncation

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,17 +1,11 @@
 name: Rust CI
 
-# ────────────────────────────────────────────────
-# Triggers
-# ────────────────────────────────────────────────
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
 
-# ────────────────────────────────────────────────
-# Global env (shared by all steps)
-# ────────────────────────────────────────────────
 env:
   CARGO_TERM_COLOR: always
   DATABASE_URL: postgres://postgres:postgres@localhost:5432/app_db
@@ -25,9 +19,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    # ────────────────────────────────────────────
-    # Service containers (PostgreSQL + Redis)
-    # ────────────────────────────────────────────
     services:
       postgres:
         image: postgres:latest
@@ -52,10 +43,7 @@ jobs:
           --health-retries 5
 
     steps:
-    # 1 ─ Checkout code
     - uses: actions/checkout@v4
-
-    # 2 ─ Install Rust toolchain + components
     - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1
       with:
@@ -64,7 +52,6 @@ jobs:
         override: true
         components: clippy,rustfmt
 
-    # 3 ─ Speed up builds by caching registry + target/
     - name: Cache cargo registry and build artifacts
       uses: actions/cache@v4
       with:
@@ -74,40 +61,34 @@ jobs:
           target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-    # 4 ─ Lint: Clippy (fails on warnings)
     - name: Run Clippy
       run: cargo clippy --all-targets --all-features -- -D warnings
 
-    # 5 ─ Formatting check
     - name: Check rustfmt
       run: cargo fmt -- --check
 
-    # 6 ─ System libs for Diesel (libpq)
+    - name: Cargo audit (deny new advisories)
+      uses: actions-rs/audit-check@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Install system dependencies
       run: sudo apt-get update && sudo apt-get install -y libpq-dev pkg-config
 
-    # 7 ─ Install Diesel CLI (PostgreSQL only)
     - name: Install Diesel CLI
       run: cargo install diesel_cli --no-default-features --features postgres
 
-    # 8 ─ Prepare database schema (drops → recreates → migrates)
     - name: Run Diesel migrations (diesel setup)
       run: diesel setup
 
-    # 9 ─ Build code
     - name: Build
       run: cargo build --all-features --verbose
 
-    # 10 ─ Launch Rocket server in background & run tests
     - name: Run tests
       shell: bash
       run: |
-        # Start server on 127.0.0.1:8000 (matches APP_HOST in tests)
         cargo run --bin server &
         SERVER_PID=$!
-        # Give it a moment to start up
         sleep 3
-        # Run test-suite (single thread avoids port contention)
         cargo test --all-features -- --test-threads=1
-        # Shut down server
         kill $SERVER_PID

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,44 @@
 # Changelog
+
 All notable changes to **cr8s** will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## \[Unreleased]
+
+*No changes yet*
+
+---
+
+## \[0.2.0] - 2025-05-04
 
 ### Added
-- **GitHub Actions** workflow (`.github/workflows/rust.yml`) with Postgres + Redis
+
+* **GitHub Actions** workflow (`.github/workflows/rust.yml`) with Postgres + Redis
   service containers, Diesel migrations, lint, build, and test steps.
-- Docker-first quick-start and expanded docs in `README.md`.
-- `docs/docker-usage.md`: cheat-sheet of common Docker Compose commands.
-- `docs/native-workflow.md`: step-by-step native (non-Docker) setup guide.
+* Docker‑first quick‑start and expanded docs in `README.md`.
+* `docs/docker-usage.md`: cheat‑sheet of common Docker Compose commands.
+* `docs/native-workflow.md`: step‑by‑step native (non‑Docker) setup guide.
 
 ### Changed
-- `docker-compose.yml`: removed deprecated `version:` key. Tests now run 
-   in the same `app` container.
-- Enabled `tokio` **macros** and **rt-multi-thread** features in `Cargo.toml`.
-- Replaced hand-written `ToString` with `Display` for `RoleCode`.
-- Ran `cargo fmt` and fixed assorted Clippy warnings.
-- Login route now returns **401 Unauthorized** for invalid credentials.
+
+* `docker-compose.yml`: removed deprecated `version:` key. Tests now run
+  in the same `app` container.
+* Enabled Tokio **macros** and **rt‑multi‑thread** features in `Cargo.toml`.
+* Replaced hand‑written `ToString` with `Display` for `RoleCode`.
+* Ran `cargo fmt` and fixed assorted Clippy warnings.
+* Login route now returns **401 Unauthorized** on bad credentials.
 
 ### Fixed
-- CI reproducibility: no host env-vars required; tests run against the
-  in-container server on `127.0.0.1:8000`.
+
+* CI reproducibility: no host env‑vars required; tests run against the
+  in‑container server on `127.0.0.1:8000`.
+
+### Security
+
+* Added `.cargo/audit.toml` to temporarily ignore **RUSTSEC‑2024‑0365** (Diesel
+  2.1 advisory). Will upgrade to Diesel 2.2 when `rocket_db_pools` and
+  `diesel‑async` publish compatible releases.
+  [#4]: https://github.com/JohnBasrai/cr8s/issues/4
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,25 +1,29 @@
 [package]
 name = "cr8s"
 default-run = "server"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
-rocket = { version = "0.5", features = ["json"] }
-rocket_db_pools = { version = "0.1", features = ["diesel_postgres", "deadpool_redis"] }
-diesel = { version = "2.1", features = ["chrono"] }
-diesel-async = { version = "0.4", features = ["postgres"] }
-serde = "1.0"
-serde_json = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
-clap = "4.4"
-argon2 = "0.5"
-rand = "0.8"
-tera = "1"
-lettre = "0.11"
+tokio            = { version = "1",   features = ["macros", "rt", "rt-multi-thread"] }
+rocket           = { version = "0.5", features = ["json"] }
+
+# Diesel 2.1 stack (compatible versions)
+rocket_db_pools  = { version = "0.2",   features = ["diesel_postgres", "deadpool_redis"] }
+diesel           = { version = "2.1",   features = ["chrono"] }          # stays on 2.1
+diesel-async     = { version = "0.4.1", features = ["postgres"] }
+
+# bumped minor/patch on misc crates
+serde            = "1.0"
+serde_json       = "1.0"
+chrono           = { version = "0.4", features = ["serde"] }
+clap             = "4.5"
+argon2           = "0.5"
+rand             = "0.9"
+tera             = "1.20"
+lettre           = "0.11"
 
 [dev-dependencies]
-reqwest = { version = "0.11", features = ["json", "blocking"] }
+reqwest          = { version = "0.12", features = ["json", "blocking"] }

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ docker compose run --rm app diesel setup
 
 # 4. Run the test-suite (server + tests in same container)
 $ docker compose run --rm --service-ports app \
-    bash -c 'cargo run --bin server & sleep 5 && cargo test -- --test-threads=1'
+    bash -c 'cargo run --bin server & sleep 3 && cargo test -- --test-threads=1'
 
 # 5. Tear everything down
 $ docker compose down
@@ -61,20 +61,41 @@ Need more Docker tips (stream logs, cURL pokes, DB maintenance)? See [`docs/dock
 ## 📂 Project layout
 
 ```
-├── src/
-│   ├── bin/
-│   │   ├── server.rs        # Rocket entry‑point
-│   │   └── cli.rs           # Maintenance CLI
-│   └── lib.rs               # Shared domain logic
-├── tests/                   # Integration tests
-├── migrations/              # Diesel SQL migrations
-├── Dockerfile               # Application image
-├── docker-compose.yml       # Dev/CI stack definition
-├── docs/
-│   ├── docker-usage.md      # Extra Docker commands (optional)
-│   └── native-workflow.md   # Community‑supported native setup
-└── .github/workflows/
-    └── rust.yml             # CI pipeline
+├── Cargo.toml
+├── CHANGELOG.md
+├── diesel.toml
+├── docker-compose.yml
+├── Dockerfile
+├── docs
+│   ├── docker-usage.md
+│   └── native-workflow.md
+├── LICENSE
+├── README.md
+├── src
+│   ├── auth.rs
+│   ├── bin
+│   │   ├── cli.rs
+│   │   └── server.rs
+│   ├── commands.rs
+│   ├── lib.rs
+│   ├── mail.rs
+│   ├── models.rs
+│   ├── repositories.rs
+│   ├── rocket_routes
+│   │   ├── authorization.rs
+│   │   ├── crates.rs
+│   │   ├── mod.rs
+│   │   └── rustaceans.rs
+│   └── schema.rs
+├── templates
+│   └── email
+│       └── digest.html
+└── tests
+    ├── authorization.rs
+    ├── common
+    │   └── mod.rs
+    ├── crates.rs
+    └── rustaceans.rs
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -29,30 +29,31 @@ Docker Compose v2       # Already bundled with modern Docker
 
 ---
 
-## 🚀 Quick start (Docker‑first workflow)
+## 🚀 Quick start (Docker-first workflow)
 
 ```bash
-# 1. Clone & build
-$ git clone https://github.com/JohnBasrai/cr8s.git && cd cr8s
-$ docker compose build              # compiles Rust into the image
+# 0 .  Clone & build the image once
+git clone https://github.com/JohnBasrai/cr8s.git && cd cr8s
+docker compose build              # compiles the Rust workspace into the app image
 
-# 2. Launch backing services (Postgres & Redis)
-$ docker compose up -d postgres redis
+# 1 .  Run the helper script – it does the rest in one shot
+./scripts/quickstart.sh
+````
 
-# 3. Initialize database (idempotent)
-$ docker compose run --rm app diesel setup
+`quickstart.sh` executes the same steps you would run manually:
 
-# 4. Run the test-suite (server + tests in same container)
-$ docker compose run --rm --service-ports app \
-    bash -c 'cargo run --bin server & sleep 3 && cargo test -- --test-threads=1'
+1. `docker compose down -v` – start clean (containers + volumes)
+2. `docker compose up -d postgres redis` – bring up Postgres & Redis
+3. Wait until Postgres accepts TCP connections, then run
+   `diesel setup` – create the database & apply migrations
+4. Launch the Rocket server and run the integration-test suite
+5. `docker compose down` – tear everything back down
 
-# 5. Tear everything down
-$ docker compose down
-```
+### What to expect
 
-* **No host env‑vars needed** – the `app` service already sets `DATABASE_URL` and `ROCKET_DATABASES` in *docker-compose.yml*, so Diesel, Rocket, and the test runner all see the right values automatically.
-* **Integrated server spin-up** – the test command starts Rocket (`cargo run --bin server & sleep 5`) on `127.0.0.1:8000`; the tests hit it via `reqwest`, exactly like in CI.
-* **Expected result** – when the suite finishes you should see something like `ok. 2 passed; 0 failed` (or however many tests exist).
+* **Exit status** – returns `0` when every step succeeds (Bash’s `set -e` will surface any error with a non-zero code).
+* **No host env-vars needed** – the `app` service injects `DATABASE_URL` and `ROCKET_DATABASES`, so Diesel, Rocket, and the tests “just work.”
+* **Successful run** – you’ll see something like `result: ok. 6 passed; 0 failed;`, and your shell prompt will return with exit code 0.
 
 Need more Docker tips (stream logs, cURL pokes, DB maintenance)? See [`docs/docker-usage.md`](docs/docker-usage.md).
 
@@ -71,6 +72,8 @@ Need more Docker tips (stream logs, cURL pokes, DB maintenance)? See [`docs/dock
 │   └── native-workflow.md
 ├── LICENSE
 ├── README.md
+├── scripts
+│   └── quickstart.sh
 ├── src
 │   ├── auth.rs
 │   ├── bin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,41 @@
-
 services:
   postgres:
     image: postgres:latest
     environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
-      - POSTGRES_DB=app_db
-    command: ["postgres", "-c", "log_statement=all"]
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: app_db
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   redis:
     image: redis:latest
+    ports:
+      - "6379:6379"
 
   app:
     build: .
+    tty: true
+    ports:
+      - "8000:8000"          # expose Rocket to host
+    volumes:
+      - ./:/app/             # hot-reload / dev editing
     environment:
-      - DATABASE_URL=postgres://postgres:postgres@postgres/app_db
-      - |
-        ROCKET_DATABASES={
-          postgres={url=postgres://postgres:postgres@postgres/app_db},
+      DATABASE_URL: postgres://postgres:postgres@postgres:5432/app_db
+      ROCKET_DATABASES: |
+        {
+          postgres={url=postgres://postgres:postgres@postgres:5432/app_db},
           redis={url=redis://redis:6379}
         }
-      - SMTP_HOST=smtp.gmail.com
-      - SMTP_USERNAME=paris.liakos@gmail.com
-      - SMTP_PASSWORD=okks qghu trly qwot
-      - FOO
-    ports:
-      - 8000:8000
-    volumes:
-      - ./:/app/
+      # (optional) e-mail creds — consider .env or secrets instead
+      SMTP_HOST: smtp.gmail.com
+      SMTP_USERNAME: you@example.com
+      SMTP_PASSWORD: okks qghu trly qwot
+    depends_on:
+      postgres:
+        condition: service_healthy

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+docker compose down -v
+docker compose up -d postgres redis
+
+# Wait for Postgres, then run migrations
+docker compose run --rm app \
+  bash -c 'until </dev/tcp/postgres/5432 >/dev/null 2>&1; do sleep 1; done && diesel setup'
+
+# Launch Rocket and run tests
+docker compose run --rm --service-ports app \
+  bash -c "cargo run --bin server & sleep 3 && cargo test -- --test-threads=1"
+
+docker compose down

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -3,7 +3,7 @@ use argon2::password_hash::Error;
 use argon2::password_hash::SaltString;
 use argon2::Argon2;
 use argon2::{PasswordHash, PasswordHasher, PasswordVerifier};
-use rand::distributions::Alphanumeric;
+use rand::distr::Alphanumeric;
 use rand::Rng;
 
 use crate::models::User;
@@ -19,7 +19,7 @@ pub fn authorize_user(user: &User, credentials: Credentials) -> Result<String, E
     let db_hash = PasswordHash::new(&user.password)?;
     argon2.verify_password(credentials.password.as_bytes(), &db_hash)?;
 
-    let session_id = rand::thread_rng()
+    let session_id: String = rand::rng()
         .sample_iter(&Alphanumeric)
         .take(128)
         .map(char::from)


### PR DESCRIPTION
* Populated CHANGELOG with the full 0.2.0 entry dated 2025-05-04:
  - new CI workflow, Docker-first docs, security ignore, etc.
* Added a Security note that links to issue #4 (tracking Diesel 2.2 support in rocket_db_pools / diesel-async).
* docs(README): replace multi-step setup with new “Docker-first workflow”
  using `scripts/quickstart.sh`; document zero-exit behavior.
* feat(scripts): add `scripts/quickstart.sh` helper to spin up Postgres/Redis,
  run Diesel migrations, launch Rocket, run tests, then tear everything down.
* chore(compose): add Postgres health-check, expose host ports, clean up
  env-var syntax, keep source mount for hot-reload, and gate app on DB health.
* fix(auth): update `rand` import for rand 0.9 (`rand::distributions::Alphanumeric`)
  so the crate builds with the newer version.

This closes the documentation loop for the 0.2.0 release.