### PR TITLE
fix: resolve author table schema mismatch causing /rustaceans 500 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## \[Unreleased]
 ---
+
+## [0.4.3] - 2025-06-02
+
+### Fixed
+- **Database Schema**: Removed incorrect `user_id` column references from author table operations
+- **API Endpoints**: Fixed 500 Internal Server Error on `/rustaceans` endpoint
+- **Repository Layer**: Corrected `AuthorRepo` SQL queries to match actual database schema
+- **Domain Model**: Aligned author domain model with intended one-way relationship design (`app_user.author_id` → `author.id`)
+
+### Technical Details
+- Removed `user_id` field from `AuthorRow` struct and all related SQL queries
+- Fixed `find_multiple`, `find`, `create`, `update` methods in `AuthorTableTrait` implementation
+- Maintained correct schema design where authors can exist independently of user accounts
+- Eliminated circular reference between `app_user` and `author` tables
+
+---
+
 ## [v0.4.2] – 2025-05-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "cr8s"
-version = "0.4.0"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cr8s"
 default-run = "server"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 authors = ["John Basrai <john@basrai.dev>"]
 description = "Backend service for the cr8s project (Rocket + SQLx + Redis)"

--- a/src/domain/author.rs
+++ b/src/domain/author.rs
@@ -16,14 +16,12 @@ pub struct Author {
     pub name: String,
     pub email: String,
     pub created_at: NaiveDateTime,
-    pub user_id: Option<i32>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct NewAuthor {
     pub name: String,
     pub email: String,
-    pub user_id: Option<i32>,
 }
 
 // Trait alias for shared trait objects

--- a/src/repository/author_sqlx.rs
+++ b/src/repository/author_sqlx.rs
@@ -22,7 +22,6 @@ struct AuthorRow {
     id: i32,
     name: String,
     email: String,
-    user_id: Option<i32>,
     created_at: chrono::NaiveDateTime,
 }
 
@@ -32,7 +31,6 @@ impl From<AuthorRow> for Author {
             id: row.id,
             name: row.name,
             email: row.email,
-            user_id: row.user_id,
             created_at: row.created_at,
         }
     }
@@ -45,14 +43,13 @@ impl AuthorTableTrait for AuthorRepo {
         // ---
         let row = sqlx::query_as::<_, AuthorRow>(
             r#"
-            INSERT INTO author (name, email, user_id)
-            VALUES ($1, $2, $3)
+            INSERT INTO author (name, email)
+            VALUES ($1, $2)
             RETURNING id, name, email, user_id, created_at
             "#,
         )
         .bind(&author.name)
         .bind(&author.email)
-        .bind(author.user_id)
         .fetch_one(&self.pool)
         .await
         .context("AuthorRepo::create failed")?;
@@ -66,14 +63,13 @@ impl AuthorTableTrait for AuthorRepo {
         let row = sqlx::query_as::<_, AuthorRow>(
             r#"
             UPDATE author
-            SET name = $1, email = $2, user_id = $3
-            WHERE id = $4
+            SET name = $1, email = $2
+            WHERE id = $3
             RETURNING id, name, email, user_id, created_at
             "#,
         )
         .bind(&author.name)
         .bind(&author.email)
-        .bind(author.user_id)
         .bind(id)
         .fetch_one(&self.pool)
         .await
@@ -87,7 +83,7 @@ impl AuthorTableTrait for AuthorRepo {
         // ---
         let author = sqlx::query_as::<_, AuthorRow>(
             r#"
-            SELECT id, name, email, user_id, created_at
+            SELECT id, name, email, created_at
             FROM author
             WHERE id = $1
             "#,
@@ -105,7 +101,7 @@ impl AuthorTableTrait for AuthorRepo {
         // ---
         let authors = sqlx::query_as::<_, AuthorRow>(
             r#"
-            SELECT id, name, email, user_id, created_at
+            SELECT id, name, email, created_at
             FROM author
             ORDER BY id
             LIMIT $1

--- a/src/repository/author_sqlx.rs
+++ b/src/repository/author_sqlx.rs
@@ -45,7 +45,7 @@ impl AuthorTableTrait for AuthorRepo {
             r#"
             INSERT INTO author (name, email)
             VALUES ($1, $2)
-            RETURNING id, name, email, user_id, created_at
+            RETURNING id, name, email, created_at
             "#,
         )
         .bind(&author.name)
@@ -65,7 +65,7 @@ impl AuthorTableTrait for AuthorRepo {
             UPDATE author
             SET name = $1, email = $2
             WHERE id = $3
-            RETURNING id, name, email, user_id, created_at
+            RETURNING id, name, email, created_at
             "#,
         )
         .bind(&author.name)

--- a/src/rocket_routes/authors.rs
+++ b/src/rocket_routes/authors.rs
@@ -135,7 +135,6 @@ mod tests {
         async fn create(&self, new: NewAuthor) -> Result<Author> {
             Ok(Author {
                 id: 42,
-                user_id: new.user_id,
                 name: new.name,
                 email: new.email,
                 created_at: Utc::now().naive_utc(),
@@ -155,7 +154,6 @@ mod tests {
     async fn test_get_authors_returns_list() {
         let author = Author {
             id: 1,
-            user_id: Some(1),
             name: "Alice".into(),
             email: "alice@example.com".into(),
             created_at: Utc::now().naive_utc(),
@@ -184,7 +182,6 @@ mod tests {
     async fn test_view_author_success() {
         let author = Author {
             id: 5,
-            user_id: Some(1),
             name: "Bob".into(),
             email: "bob@example.com".into(),
             created_at: Utc::now().naive_utc(),
@@ -221,7 +218,6 @@ mod tests {
         }));
 
         let new_author = Json(NewAuthor {
-            user_id: Some(123),
             name: "Charlie".into(),
             email: "charlie@example.com".into(),
         });
@@ -240,7 +236,6 @@ mod tests {
     async fn test_update_author_success() {
         let existing = Author {
             id: 10,
-            user_id: Some(1),
             name: "Old Name".into(),
             email: "old@example.com".into(),
             created_at: Utc::now().naive_utc(),
@@ -258,7 +253,6 @@ mod tests {
 
         let updated = Json(Author {
             id: 10,
-            user_id: Some(1),
             name: "Updated Name".into(),
             email: "updated@example.com".into(),
             created_at: Utc::now().naive_utc(),
@@ -279,7 +273,6 @@ mod tests {
     async fn test_delete_author_success() {
         let author = Author {
             id: 7,
-            user_id: Some(1),
             name: "ToDelete".into(),
             email: "delete@example.com".into(),
             created_at: Utc::now().naive_utc(),


### PR DESCRIPTION
## Problem
The `/rustaceans` endpoint was returning 500 Internal Server Error due to SQL queries attempting to select a non-existent `user_id` column from the `author` table.

## Root Cause
Backend code expected `author.user_id` column but database schema correctly implements one-way relationship `app_user.author_id` → `author.id` without reverse reference.

## Solution
- Removed `user_id` references from `AuthorRepo` SQL queries
- Updated domain model to match intended schema design
- Maintained correct one-way relationship design

## Testing
- [ ] `/rustaceans` endpoint returns 200 OK
- [ ] Author CRUD operations work correctly  
- [ ] Database schema matches documentation

## Version Bump
- Bumped version to 0.4.3
- Updated changelog with fix details