### PR TITLE
Add `load-schema` CLI command for database initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## \[Unreleased]
 
+## [0.4.7] - 2025-06-04
+
+### Added
+- New CLI command: `load-schema`
+  - Loads database schema and default roles from a SQL file (`scripts/sql/db-init.sql`)
+  - Path can be overridden with the `CR8S_DB_INIT_SQL` environment variable
+  - Automatically initializes the database connection pool before execution
+  - Replaces the deprecated `init-default-roles` command
+
 ---
+
 ## [0.4.6] - 2025-06-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "cr8s"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cr8s"
 default-run = "server"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 authors = ["John Basrai <john@basrai.dev>"]
 description = "Backend service for the cr8s project (Rocket + SQLx + Redis)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,5 +60,6 @@ USER root
 RUN /bin/sh -c 'echo "🔨 Building runtime CLI container" >&2'
 WORKDIR /app
 COPY --from=builder /app/target/release/cli /app/cli
+COPY --chown=appuser:appuser scripts/sql/db-init.sql /app/
 USER appuser
 ENTRYPOINT ["./cli"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Sample full‑stack **Rust** web service demonstrating clean architecture, trait
 | HTTP  | **Rocket 0.5** | Async web framework |
 | DB    | **SQLx** + **PostgreSQL** | Async SQL with runtime verification |
 | Cache | **Redis** | Session / ephemeral storage |
-| Admin | CLI binary (`cargo run --bin cli`) | User management with trait-based architecture |
+| Admin | CLI binary (`cargo run --bin cli`) | User management, DB setup, and admin utilities |
 | Tests | `tokio`, `reqwest`, `sqlx` | Async/await integration tests with role-based auth |
 | Dev   | **Docker Compose** | One‑command reproducible stack |
 | CI    | **GitHub Actions** | Lint → migrate → build → test |
@@ -46,6 +46,17 @@ docker compose up -d postgres redis
 cargo run                      # backend starts on :8000
 ```
 
+### Initialize database schema
+
+```bash
+# Run using local cargo, prebuilt Docker, or Compose
+cargo run --bin cli -- load-schema
+docker compose run cli load-schema
+```
+
+This executes `scripts/sql/db-init.sql` and inserts default roles.
+Use `CR8S_DB_INIT_SQL=/path/to/alt.sql` to override the default file.
+
 ### With Frontend (`cr8s-fe`)
 
 See the **cr8s-fe** repository for full-stack development instructions.
@@ -73,8 +84,7 @@ cr8s/
 │
 ├── templates/email/           # Tera email templates
 ├── scripts/                   # development & deployment scripts
-│   ├── sql/db-init.sql       # database schema initialization
-│   └── quickstart-dev.sh     # one-shot dev bootstrap
+│   ├── quickstart-dev.sh      # one-shot dev bootstrap
 └── docs/                      # Docker tips & native workflow
 ```
 

--- a/docs/CR8S - Architecture.md
+++ b/docs/CR8S - Architecture.md
@@ -50,6 +50,7 @@ The repository layer demonstrates clear separation of concerns through focused, 
 | `crate_sqlx.rs`         | Rust crate/package metadata                 |
 | `role_code_sqlx.rs`     | Permission and role-based access control    |
 | `database.rs`           | Database connection and lifecycle management |
+| `load_schema_from_sql_file()` | Loads schema and default roles from SQL file   |
 | `redis_cache.rs`        | Session and ephemeral data caching          |
 | `env.rs`                | Environment configuration management        |
 | `health_check.rs`       | System diagnostics and monitoring           |
@@ -63,6 +64,13 @@ This modular design ensures that:
 - Infrastructure details remain hidden behind domain interfaces
 
 ### 6. Repository Layer
+
+The `repository/database.rs` module also includes `load_schema_from_sql_file()`, 
+which is invoked by the CLI `load-schema` command. It reads a SQL file (defaulting 
+to `scripts/sql/db-init.sql`), initializes the connection pool if necessary, and 
+executes the script as a batch — including insertion of default roles. The path 
+can be overridden using the `CR8S_DB_INIT_SQL` environment variable.
+
 
 Core SQLx-backed types (e.g. `AppUser`, `UserRole`, etc.) are defined in `src/repository/*_sqlx.rs` files, each focused on a specific domain entity.
 

--- a/docs/CR8S - Database Schema.md
+++ b/docs/CR8S - Database Schema.md
@@ -128,3 +128,17 @@ src/mock/
 The design applies the **Dependency Inversion Principle**, ensuring all high-level logic depends on interfaces, not implementations.
 
 ---
+
+## Schema Initialization
+
+The `cr8s` schema and default roles (`Admin`, `Editor`, `Viewer`) are loaded using the CLI:
+
+```bash
+# All of these will work
+cargo run --bin cli -- load-schema
+docker compose run cli load-schema
+
+This executes `scripts/sql/db-init.sql` in full, and ensures the `role` table is pre-populated.
+
+Use `CR8S_DB_INIT_SQL=/path/to/alt.sql` to override the default file.
+

--- a/scripts/sql/db-init.sql
+++ b/scripts/sql/db-init.sql
@@ -88,3 +88,8 @@ CREATE TABLE user_roles (
   role_id INTEGER NOT NULL REFERENCES role(id) ON DELETE CASCADE,
   CONSTRAINT user_role_unique UNIQUE (user_id, role_id)
 );
+
+INSERT INTO role (code, name) VALUES
+  ('Admin', 'Administrator'),
+  ('Editor', 'Editor'),
+  ('Viewer', 'Viewer');

--- a/scripts/sql/load-defaults.sql
+++ b/scripts/sql/load-defaults.sql
@@ -1,7 +1,0 @@
--- Default data for testing and development
-INSERT INTO role (code, name) VALUES 
-  ('Admin', 'Administrator'),
-  ('Editor', 'Editor'), 
-  ('Viewer', 'Viewer');
-
--- Add any other default data needed for testing

--- a/src/bin/cli/cli.rs
+++ b/src/bin/cli/cli.rs
@@ -73,8 +73,8 @@ pub enum Commands {
         hours_since: i32,
     },
 
-    /// Initialize default roles in the system
-    InitDefaultRoles,
+    /// Load cr8s schema and default roles into the database
+    LoadSchema,
 }
 
 // ---
@@ -355,16 +355,16 @@ mod tests {
     // ---
 
     #[test]
-    fn test_init_default_roles() -> Result<()> {
+    fn test_init_database() -> Result<()> {
         // ---
 
-        let args = Cli::parse_from(["cr8s-cli", "init-default-roles"]);
+        let args = Cli::parse_from(["cr8s-cli", "init-database"]);
 
         match args.command {
-            Commands::InitDefaultRoles => {
+            Commands::InitDatabase => {
                 // No parameters to check
             }
-            _ => anyhow::bail!("Expected InitDefaultRoles command"),
+            _ => anyhow::bail!("Expected InitDatabase command"),
         }
 
         Ok(())

--- a/src/bin/cli/commands.rs
+++ b/src/bin/cli/commands.rs
@@ -219,14 +219,6 @@ pub async fn digest_send(email: String, hours_since: i32) -> Result<()> {
 
 // ---
 
-pub async fn init_default_roles() -> Result<()> {
-    // ---
-
-    anyhow::bail!("init_default_roles is no longer supported")
-}
-
-// ---
-
 #[cfg(test)]
 mod tests {
 

--- a/src/bin/cli/main.rs
+++ b/src/bin/cli/main.rs
@@ -18,7 +18,6 @@ use commands::{
     delete_user_by_id,
     delete_user_by_username,
     digest_send,
-    init_default_roles,
     list_users_formatted,
     user_exists,
 };
@@ -26,6 +25,8 @@ use cr8s::domain::{
     //
     init_cache_with_retry_from_env,
     init_database_with_retry_from_env,
+    // -- Call into dab module to initialize cr8s schema and default roles
+    load_schema_from_sql_file,
 };
 
 // ---
@@ -91,8 +92,7 @@ async fn main() -> Result<()> {
         }
 
         Commands::DigestSend { email, hours_since } => digest_send(email, hours_since).await,
-
-        Commands::InitDefaultRoles => init_default_roles().await,
+        Commands::LoadSchema => load_schema_from_sql_file().await,
     }
 }
 

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -107,3 +107,5 @@ pub async fn init_database_with_retry_from_env() -> anyhow::Result<()> {
 pub async fn init_cache_with_retry_from_env() -> anyhow::Result<()> {
     crate::repository::init_cache_with_retry_from_env().await
 }
+
+pub use crate::repository::load_schema_from_sql_file;

--- a/src/repository/database.rs
+++ b/src/repository/database.rs
@@ -17,6 +17,13 @@ pub async fn init_database_with_retry_from_env() -> Result<()> {
     // ---
     let url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
 
+    let fname = "init_database_with_retry_from_env";
+
+    if POOL.get().is_some() {
+        tracing::info!("{fname}: Pool is already initialized");
+        return Ok(());
+    }
+
     tracing::info!("🚨 Rocket attaching to database at: {:?}", url);
 
     let retry_max = crate::get_env_with_default!(u32, "CR8S_DB_RETRY_COUNT", 50);
@@ -31,15 +38,17 @@ pub async fn init_database_with_retry_from_env() -> Result<()> {
             .await
         {
             Ok(pool) => {
-                POOL.set(pool)
-                    .map_err(|_| anyhow!("Pool already initialized"))?;
+                if POOL.set(pool).is_err() {
+                    // This would happen only if this function is called from multiple
+                    // thread concurrently which is not supposed to happen.  It is race
+                    // condition and we just drop the new (2nd) one.
+                    tracing::warn!("{fname}: Pool is already initialized");
+                }
                 return Ok(());
             }
             Err(e) if attempt == retry_max => {
                 return Err(anyhow!(
-                    "Failed to connect to DB after {} retries: {}",
-                    retry_max,
-                    e
+                    "{fname}: Failed to connect to DB after {retry_max} retries: {e}"
                 ));
             }
             Err(_) => {
@@ -62,4 +71,37 @@ pub(crate) fn get_pool() -> &'static PgPool {
     // ---
     POOL.get()
         .expect("Pool not initialized. Call init_pool_with_retry() first.")
+}
+
+/// Initialize cr8s schema and default roles, called from cli init-database command
+///
+pub async fn load_schema_from_sql_file() -> Result<()> {
+    // ---
+
+    use anyhow::Context;
+    use std::env;
+    use std::fs;
+
+    let path = env::var("CR8S_DB_INIT_SQL").unwrap_or_else(|_| "db-init.sql".to_string());
+
+    init_database_with_retry_from_env().await?;
+
+    let contents = fs::read_to_string(&path)
+        .with_context(|| format!("Failed to read SQL file at '{}'", path))?;
+
+    let pool = get_pool();
+
+    sqlx::query(&contents)
+        .execute(&*pool)
+        .await
+        .with_context(|| {
+            let preview: String = contents.chars().take(500).collect();
+            format!(
+                "Failed to execute SQL init script at '{}'\n--- Preview ---\n{}",
+                path, preview
+            )
+        })?;
+
+    println!("✅ Database initialized from {}", path);
+    Ok(())
 }

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -31,6 +31,7 @@ pub use app_user_sqlx::create_app_user_repo;
 pub use author_sqlx::create_author_repo;
 pub use crate_sqlx::create_crate_repo;
 pub use database::init_database_with_retry_from_env;
+pub use database::load_schema_from_sql_file;
 pub use health_check::create_cache_health_service;
 pub use health_check::create_database_health_service;
 pub use redis_cache::create_cache_context;


### PR DESCRIPTION
This PR closes **#27** by replacing the deprecated `init-default-roles` command with a unified, production-safe `load-schema` CLI tool to initialize the cr8s database schema and default roles.

### Key Features:

* ✅ **New CLI command: `load-schema`**

  * Loads `scripts/sql/db-init.sql` and inserts `Admin`, `Editor`, `Viewer` roles
  * Initializes the pool via `init_database_with_retry_from_env()`
  * Supports alternate SQL paths via `CR8S_DB_INIT_SQL`
  * Can be invoked via `cargo`, `docker run`, or `docker compose run`

* ✅ **Documentation updates:**

  * **README.md**: CLI usage examples with local/Docker/Compose
  * **Architecture.md**: Added entry for `load_schema_from_sql_file()`
  * **Database Schema.md**: New “Schema Initialization” section

* ✅ **Other changes:**

  * Removed `init-default-roles` CLI command and unused stub
  * Merged `load-defaults.sql` into `db-init.sql` for single-step setup
  * Bumped version to `v0.4.7` in `Cargo.toml` and `CHANGELOG.md`
  * Copies scripts/sql/db-init.sql into the CLI container image to support default path used by load-schema

This command supports:

* Developer onboarding
* Local/CI integration testing
* Schema setup for new deployments

**Closes #27**
